### PR TITLE
Build and publish in one job to drop Node 20 artifact actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,12 @@ on:
       - 'v*'
 
 jobs:
-  build:
-    name: build distributions
+  pypi-publish:
+    name: build and publish to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for trusted publishing
     steps:
       - uses: actions/checkout@v5
 
@@ -17,24 +20,6 @@ jobs:
 
       - name: build sdist and wheel
         run: uv build
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-  pypi-publish:
-    name: publish to PyPI
-    needs: build
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write  # required for trusted publishing
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
 
       - name: publish
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Removes the `actions/upload-artifact` / `download-artifact` steps that triggered Node 20 deprecation warnings (forced to Node 24 from June 2026, no Node 24 release available yet).

By building and publishing in the same `pypi-publish` job, the dist files no longer need to be passed between jobs, so both artifact actions are dropped. The remaining actions (`checkout@v5`, `setup-uv@v7`, `gh-action-pypi-publish`) are already Node 24 / Docker based.

Behaviour is unchanged: tag push → build → publish to PyPI via trusted publishing → create GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)