### PR TITLE
Add Django Packages badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI version](https://badge.fury.io/py/django-query-counter.svg)](https://badge.fury.io/py/django-query-counter)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-query-counter)
 ![PyPI - Versions from Framework Classifiers](https://img.shields.io/pypi/frameworkversions/django/django-query-counter)
+[![Latest on Django Packages](https://img.shields.io/badge/Django%20Packages-django--query--counter-8c3c26.svg)](https://djangopackages.org/packages/p/django-query-counter/)
 
 
 A small debug tool that counts the SQL queries Django runs and prints a summary


### PR DESCRIPTION
Package is listed on https://djangopackages.org/packages/p/django-query-counter/ now, so added their badge to the README header.

The snippet djangopackages.org hands out is a raw template — `{{ package.slug }}` unsubstituted, and the slug's hyphens unescaped. Shields.io parses `badge/label-message-color` on hyphens, so the literal path 404s:

```
$ curl -s https://img.shields.io/badge/PyPI-django-query-counter-tags-8c3c26.svg | grep title
<title>404: badge not found</title>
```

Escaped them as `--`, which renders `Django Packages | django-query-counter`. Also dropped the `PyPI` label from the template — there is already a `PyPI version` badge one line above, and two badges labelled the same pointing at different sites reads as a mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)